### PR TITLE
use floats for cluster and plan memory, revamp API client

### DIFF
--- a/internal/bridgeapi/client.go
+++ b/internal/bridgeapi/client.go
@@ -30,13 +30,15 @@ import (
 	"github.com/google/uuid"
 )
 
-var (
-	routeAccount       string = "/account"
-	routeClusters      string = "/clusters"
-	routeClusterRole   string = "/clusters/%s/roles"
-	routeClusterStatus string = "/clusters/%s/status"
-	routeProviders     string = "/providers"
-	routeTeams         string = "/teams"
+const (
+	routeAccount        = "/account"
+	routeCluster        = "/clusters/%s"
+	routeClusterUpgrade = "/clusters/%s/upgrade"
+	routeClusters       = "/clusters"
+	routeClusterRole    = "/clusters/%s/roles/%s"
+	routeClusterStatus  = "/clusters/%s/status"
+	routeProviders      = "/providers"
+	routeTeams          = "/teams"
 )
 
 var (
@@ -267,4 +269,20 @@ func (c *Client) setRequestUserAgent(req *http.Request) {
 func (c *Client) setCommonHeaders(req *http.Request) {
 	c.setRequestBearer(req)
 	c.setRequestUserAgent(req)
+}
+
+func (c *Client) resolve(path string, params ...url.Values) *url.URL {
+	u := c.apiTarget.ResolveReference(&url.URL{Path: path})
+
+	q := u.Query()
+
+	for _, p := range params {
+		for name, value := range p {
+			q[name] = value
+		}
+	}
+
+	u.RawQuery = q.Encode()
+
+	return u
 }

--- a/internal/bridgeapi/cluster.go
+++ b/internal/bridgeapi/cluster.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,6 +17,7 @@ package bridgeapi
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -25,248 +26,136 @@ import (
 	"github.com/google/uuid"
 )
 
-func (c *Client) CreateCluster(cr CreateRequest) (string, error) {
-	if err := c.login(); err != nil {
-		return "", err
-	}
+func (c *Client) CreateCluster(ctx context.Context, cr CreateRequest) (_ string, outErr error) {
+	route := c.resolve(routeClusters)
 
 	reqPayload, err := json.Marshal(cr)
 	if err != nil {
-		return "", fmt.Errorf("error during cluser request encoding: %w", err)
+		return "", fmt.Errorf("error during cluster request encoding: %w", err)
 	}
-	req, err := http.NewRequest(http.MethodPost, c.apiTarget.String()+routeClusters, bytes.NewReader(reqPayload))
+
+	idempotencyOpt := func(req *http.Request) {
+		if c.useIdempotencyKey {
+			// Set Idempotency Key based on payload content
+			//
+			// API is expecting UUID for the value, but we're using
+			// UUIDv5 so that the key matches the request payload.
+			idemKey := uuid.NewSHA1(BridgeProviderNS, reqPayload)
+
+			req.Header.Set("Idempotency-Key", idemKey.String())
+		}
+	}
+
+	resp, err := c.do(
+		ctx, http.MethodPost, route,
+		bytes.NewReader(reqPayload), idempotencyOpt,
+	)
 	if err != nil {
-		return "", fmt.Errorf("during create cluster request: %w", err)
+		return "", err
 	}
 
-	c.setCommonHeaders(req)
+	defer safeClose(&outErr, resp.Body, "response body")
 
-	// Set Idempotency Key based on payload content
-	//
-	// API is expecting UUID for the value, but we're using UUIDv5 so that
-	// the key matches the request payload
-	if c.useIdempotencyKey {
-		idemKey := uuid.NewSHA1(BridgeProviderNS, reqPayload)
-		req.Header.Set("Idempotency-Key", idemKey.String())
-	}
-
-	resp, err := c.client.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("during create cluster: %w", err)
-	}
-	defer resp.Body.Close()
-
-	// APIMessage is the default response format when the API function doesn't
-	// return the documented response type
-	var mesg APIMessage
 	if resp.StatusCode != http.StatusCreated {
-		err = json.NewDecoder(resp.Body).Decode(&mesg)
-		if err != nil {
-			// Move forward with errors based on http code
-			mesg.Message = "unable to retrieve further error details"
-		}
+		return "", errorFromAPIMessageResponse(resp)
 	}
 
-	switch resp.StatusCode {
-	case http.StatusCreated:
-		var idOnly struct {
-			ID string `json:"id"`
-		}
-		err = json.NewDecoder(resp.Body).Decode(&idOnly)
-		if err != nil {
-			return "", fmt.Errorf("unable to retrieve cluster ID from successful create response: %w", err)
-		} else {
-			return idOnly.ID, nil
-		}
-	case http.StatusBadRequest:
-		return "", fmt.Errorf("create API bad request message %w: %s, request_id: %s", ErrorBadRequest, mesg.Message, mesg.RequestID)
-	case http.StatusConflict:
-		return "", fmt.Errorf("create API conflict message %w: %s, request_id: %s", ErrorConflict, mesg.Message, mesg.RequestID)
-	default:
-		return "", fmt.Errorf("unrecognized return status from create call, code: %d, message: %s", resp.StatusCode, mesg.Message)
+	var idOnly struct {
+		ID string `json:"id"`
 	}
+
+	err = json.NewDecoder(resp.Body).Decode(&idOnly)
+	if err != nil {
+		return "", fmt.Errorf("failed to unmarshal response body: %w", err)
+	}
+
+	return idOnly.ID, nil
 }
 
-func (c *Client) DeleteCluster(id string) error {
-	if err := c.login(); err != nil {
-		return err
-	}
+func (c *Client) DeleteCluster(ctx context.Context, id string) error {
+	route := c.resolve(fmt.Sprintf(routeCluster, id))
 
-	route := fmt.Sprintf("%s%s/%s", c.apiTarget, routeClusters, id)
-
-	req, err := http.NewRequest(http.MethodDelete, route, nil)
-	if err != nil {
-		return fmt.Errorf("during cluster delete request: %w", err)
-	}
-	c.setCommonHeaders(req)
-
-	resp, err := c.client.Do(req)
-	if err != nil {
-		return fmt.Errorf("during cluster delete request prep: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("unexpected response status from API, status: %d", resp.StatusCode)
-	}
-
-	return nil
+	return c.doExec(ctx, http.MethodDelete, route, http.StatusOK)
 }
 
-func (c *Client) ClusterDetail(id string) (ClusterDetail, error) {
-	if err := c.login(); err != nil {
-		return ClusterDetail{}, err
-	}
-
-	route := fmt.Sprintf("%s%s/%s", c.apiTarget, routeClusters, id)
-
-	req, err := http.NewRequest(http.MethodGet, route, nil)
-	if err != nil {
-		return ClusterDetail{}, fmt.Errorf("during cluster detail request: %w", err)
-	}
-	c.setCommonHeaders(req)
-
-	resp, err := c.client.Do(req)
-	if err != nil {
-		return ClusterDetail{}, fmt.Errorf("during cluster detail request prep: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return ClusterDetail{}, fmt.Errorf("unexpected response status from API, status: %d", resp.StatusCode)
-	}
+func (c *Client) ClusterDetail(ctx context.Context, id string) (ClusterDetail, error) {
+	route := c.resolve(fmt.Sprintf(routeCluster, id))
 
 	var detail ClusterDetail
-	err = json.NewDecoder(resp.Body).Decode(&detail)
+
+	err := c.doJSON(ctx, http.MethodGet, route, &detail)
 	if err != nil {
-		return ClusterDetail{}, fmt.Errorf("error unmarshaling response body (cluster detail): %w", err)
+		return ClusterDetail{}, err
 	}
 
 	return detail, nil
 }
 
-func (c *Client) ClusterStatus(id string) (ClusterStatus, error) {
-	if err := c.login(); err != nil {
-		return ClusterStatus{}, err
-	}
-
-	statusRoute := fmt.Sprintf(routeClusterStatus, id)
-	route := fmt.Sprint(c.apiTarget, statusRoute)
-
-	req, err := http.NewRequest(http.MethodGet, route, nil)
-	if err != nil {
-		return ClusterStatus{}, fmt.Errorf("during cluster status request: %w", err)
-	}
-	c.setCommonHeaders(req)
-
-	resp, err := c.client.Do(req)
-	if err != nil {
-		return ClusterStatus{}, fmt.Errorf("during cluster status request prep: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return ClusterStatus{}, fmt.Errorf("unexpected response status from API, status: %d", resp.StatusCode)
-	}
+func (c *Client) ClusterStatus(ctx context.Context, id string) (ClusterStatus, error) {
+	route := c.resolve(fmt.Sprintf(routeClusterStatus, id))
 
 	var status ClusterStatus
-	err = json.NewDecoder(resp.Body).Decode(&status)
+
+	err := c.doJSON(ctx, http.MethodGet, route, &status)
 	if err != nil {
-		return ClusterStatus{}, fmt.Errorf("error unmarshaling response body (cluster status): %w", err)
+		return ClusterStatus{}, err
 	}
 
 	return status, nil
 }
 
-func (c *Client) ClusterRoles(id string) ([]ClusterRole, error) {
-	if err := c.login(); err != nil {
-		return []ClusterRole{}, err
-	}
-
-	roleRoute := fmt.Sprintf(routeClusterRole, id)
+func (c *Client) ClusterRoles(ctx context.Context, id string) ([]ClusterRole, error) {
 	roles := []string{"postgres", "application"}
 
-	defaultRoles := make([]ClusterRole, 0, 2)
-	for _, role := range roles {
-		route := fmt.Sprintf("%s%s/%s", c.apiTarget, roleRoute, role)
+	defaultRoles := make([]ClusterRole, len(roles))
 
-		req, err := http.NewRequest(http.MethodGet, route, nil)
-		if err != nil {
-			return []ClusterRole{}, fmt.Errorf("during cluster role [%s] request: %w", role, err)
-		}
-		c.setCommonHeaders(req)
-
-		resp, err := c.client.Do(req)
-		if err != nil {
-			return []ClusterRole{}, fmt.Errorf("during cluster role [%s] request prep: %w", role, err)
-		}
-		defer resp.Body.Close()
-
-		if resp.StatusCode != http.StatusOK {
-			return []ClusterRole{}, fmt.Errorf("unexpected response status from API, role: %s, status: %d", role, resp.StatusCode)
-		}
+	for i, role := range roles {
+		route := c.resolve(fmt.Sprintf(routeClusterRole, id, role))
 
 		var roleInfo ClusterRole
-		err = json.NewDecoder(resp.Body).Decode(&roleInfo)
+
+		err := c.doJSON(ctx, http.MethodGet, route, &roleInfo)
 		if err != nil {
-			return []ClusterRole{}, fmt.Errorf("error unmarshaling response body (cluster role: %s): %w", role, err)
+			return nil, fmt.Errorf("failed to get cluster role %q: %w", role, err)
 		}
-		defaultRoles = append(defaultRoles, roleInfo)
+
+		defaultRoles[i] = roleInfo
 	}
 
 	return defaultRoles, nil
 }
 
-func (c *Client) ClustersForTeam(team_id string) ([]ClusterDetail, error) {
-	if err := c.login(); err != nil {
-		return []ClusterDetail{}, err
+func (c *Client) ClustersForTeam(
+	ctx context.Context, teamID string,
+) ([]ClusterDetail, error) {
+	route := c.resolve(routeClusters, url.Values{
+		"team_id": []string{teamID},
+	})
+
+	var details struct {
+		Clusters []ClusterDetail `json:"clusters"`
 	}
 
-	route := fmt.Sprint(c.apiTarget, routeClusters)
-
-	req, err := http.NewRequest(http.MethodGet, route, nil)
+	err := c.doJSON(ctx, http.MethodGet, route, &details)
 	if err != nil {
-		return []ClusterDetail{}, fmt.Errorf("during get clusters request: %w", err)
-	}
-	c.setCommonHeaders(req)
-
-	params := url.Values{}
-	params.Add("team_id", team_id)
-	req.URL.RawQuery = params.Encode()
-
-	resp, err := c.client.Do(req)
-	if err != nil {
-		return []ClusterDetail{}, fmt.Errorf("during get clusters request prep: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return []ClusterDetail{}, fmt.Errorf("unexpected response status from API, status: %d", resp.StatusCode)
-	}
-
-	details := struct {
-		Clusters []ClusterDetail
-	}{}
-	err = json.NewDecoder(resp.Body).Decode(&details)
-	if err != nil {
-		return []ClusterDetail{}, fmt.Errorf("error unmarshaling response body (get clusters): %w", err)
+		return nil, err
 	}
 
 	return details.Clusters, nil
 }
 
-func (c *Client) GetAllClusters() ([]ClusterDetail, error) {
-	teams, err := c.AccountTeams()
+func (c *Client) GetAllClusters(ctx context.Context) ([]ClusterDetail, error) {
+	teams, err := c.AccountTeams(ctx)
 	if err != nil {
-		return []ClusterDetail{}, fmt.Errorf("error while querying team membership: %w", err)
+		return nil, fmt.Errorf("failed to get team memberships: %w", err)
 	}
 
-	allClusters := []ClusterDetail{}
+	var allClusters []ClusterDetail
 
 	for _, team := range teams {
-		teamClusters, err := c.ClustersForTeam(team.ID)
+		teamClusters, err := c.ClustersForTeam(ctx, team.ID)
 		if err != nil {
-			return []ClusterDetail{}, fmt.Errorf("error while querying clusters for team %s: %w", team.ID, err)
+			return nil, fmt.Errorf("failed to get clusters for team %s: %w", team.ID, err)
 		}
 
 		allClusters = append(allClusters, teamClusters...)
@@ -275,62 +164,52 @@ func (c *Client) GetAllClusters() ([]ClusterDetail, error) {
 	return allClusters, nil
 }
 
-func (c *Client) UpdateCluster(id string, ur ClusterUpdateRequest) error {
-	if err := c.login(); err != nil {
-		return err
-	}
-
-	route := fmt.Sprintf("%s%s/%s", c.apiTarget, routeClusters, id)
+func (c *Client) UpdateCluster(
+	ctx context.Context, id string, ur ClusterUpdateRequest,
+) (outErr error) {
+	route := c.resolve(fmt.Sprintf(routeCluster, id))
 
 	reqPayload, err := json.Marshal(ur)
 	if err != nil {
 		return fmt.Errorf("error during cluser update encoding: %w", err)
 	}
-	req, err := http.NewRequest(http.MethodPatch, route, bytes.NewReader(reqPayload))
+
+	resp, err := c.do(ctx, http.MethodPatch, route, bytes.NewReader(reqPayload))
 	if err != nil {
-		return fmt.Errorf("during cluster update request: %w", err)
-	}
-	c.setCommonHeaders(req)
-
-	resp, err := c.client.Do(req)
-	if err != nil {
-		return fmt.Errorf("during cluster update request prep: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		return fmt.Errorf("unexpected response status from API, status: %d", resp.StatusCode)
+		return err
 	}
 
-	return nil
+	defer safeClose(&outErr, resp.Body, "response body")
+
+	switch resp.StatusCode {
+	case http.StatusOK, http.StatusCreated:
+		return nil
+	default:
+		return errorFromAPIMessageResponse(resp)
+	}
 }
 
-func (c *Client) UpgradeCluster(id string, ur ClusterUpgradeRequest) error {
-	if err := c.login(); err != nil {
-		return err
-	}
-
-	route := fmt.Sprintf("%s%s/%s/upgrade", c.apiTarget, routeClusters, id)
+func (c *Client) UpgradeCluster(
+	ctx context.Context, id string, ur ClusterUpgradeRequest,
+) (outErr error) {
+	route := c.resolve(fmt.Sprintf(routeClusterUpgrade, id))
 
 	reqPayload, err := json.Marshal(ur)
 	if err != nil {
 		return fmt.Errorf("error during cluser update encoding: %w", err)
 	}
-	req, err := http.NewRequest(http.MethodPost, route, bytes.NewReader(reqPayload))
+
+	resp, err := c.do(ctx, http.MethodPost, route, bytes.NewReader(reqPayload))
 	if err != nil {
-		return fmt.Errorf("during cluster update request: %w", err)
-	}
-	c.setCommonHeaders(req)
-
-	resp, err := c.client.Do(req)
-	if err != nil {
-		return fmt.Errorf("during cluster update request prep: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		return fmt.Errorf("unexpected response status from API, status: %d", resp.StatusCode)
+		return err
 	}
 
-	return nil
+	defer safeClose(&outErr, resp.Body, "response body")
+
+	switch resp.StatusCode {
+	case http.StatusOK, http.StatusCreated:
+		return nil
+	default:
+		return errorFromAPIMessageResponse(resp)
+	}
 }

--- a/internal/bridgeapi/errors.go
+++ b/internal/bridgeapi/errors.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,13 @@ limitations under the License.
 */
 package bridgeapi
 
-import "errors"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+)
 
 var (
 	ErrorBadRequest = errors.New("invalid request")
@@ -23,3 +29,34 @@ var (
 
 	ErrorOldSecretFormat = errors.New("unexpected format for api secret, regeneration may be needed")
 )
+
+func errorFromAPIMessageResponse(resp *http.Response) error {
+	// APIMessage is the default response format when the API function doesn't
+	// return the documented response type
+	var mesg APIMessage
+	if resp.StatusCode != http.StatusCreated {
+		err := json.NewDecoder(resp.Body).Decode(&mesg)
+		if err != nil {
+			// Move forward with errors based on http code
+			mesg.Message = "unable to retrieve further error details"
+		}
+	}
+
+	if mesg.RequestID == "" {
+		return fmt.Errorf("server responded with %s: %s",
+			resp.Status, mesg.Message)
+	}
+
+	return fmt.Errorf("server responded with %s, request_id: %s: %s",
+		resp.Status, mesg.RequestID, mesg.Message)
+}
+
+func safeClose(outErr *error, c io.Closer, nameFormat string, a ...any) {
+	err := c.Close()
+	if err != nil {
+		name := fmt.Sprintf(nameFormat, a...)
+
+		*outErr = errors.Join(*outErr, fmt.Errorf(
+			"failed to close %s: %w", name, err))
+	}
+}

--- a/internal/bridgeapi/models.go
+++ b/internal/bridgeapi/models.go
@@ -39,7 +39,7 @@ type ClusterDetail struct {
 	HighAvailability bool      `json:"is_ha"`
 	PGMajorVersion   int       `json:"major_version"`
 	MaintWindowStart int       `json:"maintenance_window_start"`
-	MemoryGB         int       `json:"memory"`
+	MemoryGB         float64   `json:"memory"`
 	Name             string    `json:"name"`
 	PlanID           string    `json:"plan_id"`
 	ProviderID       string    `json:"provider_id"`
@@ -116,11 +116,11 @@ type ProviderDisk struct {
 }
 
 type Plan struct {
-	ID     string `json:"id"`
-	CPU    int    `json:"cpu"`
-	Memory int    `json:"memory"`
-	Name   string `json:"display_name"`
-	Rate   int    `json:"rate"`
+	ID       string  `json:"id"`
+	CPU      int     `json:"cpu"`
+	MemoryGB float64 `json:"memory"`
+	Name     string  `json:"display_name"`
+	Rate     int     `json:"rate"`
 }
 
 type Region struct {

--- a/internal/bridgeapi/quick_get.go
+++ b/internal/bridgeapi/quick_get.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,109 +16,124 @@ limitations under the License.
 package bridgeapi
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
+	"net/url"
 )
 
-func (c *Client) Account() (Account, error) {
-	if err := c.login(); err != nil {
+func (c *Client) Account(ctx context.Context) (Account, error) {
+	route := c.resolve(routeAccount)
+
+	var account Account
+
+	err := c.doJSON(ctx, http.MethodGet, route, &account)
+	if err != nil {
 		return Account{}, err
 	}
 
-	route := fmt.Sprint(c.apiTarget, routeAccount)
-
-	req, err := http.NewRequest(http.MethodGet, route, nil)
-	if err != nil {
-		return Account{}, fmt.Errorf("during account detail request: %w", err)
-	}
-	c.setCommonHeaders(req)
-
-	resp, err := c.client.Do(req)
-	if err != nil {
-		return Account{}, fmt.Errorf("during account detail request prep: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return Account{}, fmt.Errorf("unexpected response status from API, status: %d", resp.StatusCode)
-	}
-
-	var acct Account
-	err = json.NewDecoder(resp.Body).Decode(&acct)
-	if err != nil {
-		return Account{}, fmt.Errorf("error unmarshaling response body (account detail): %w", err)
-	}
-
-	return acct, nil
+	return account, nil
 }
 
-func (c *Client) AccountTeams() (Teams, error) {
-	if err := c.login(); err != nil {
-		return []Team{}, err
+func (c *Client) AccountTeams(ctx context.Context) (Teams, error) {
+	route := c.resolve(routeTeams)
+
+	var response struct {
+		Teams Teams `json:"teams"`
 	}
 
-	route := fmt.Sprint(c.apiTarget, routeTeams)
-
-	req, err := http.NewRequest(http.MethodGet, route, nil)
+	err := c.doJSON(ctx, http.MethodGet, route, &response)
 	if err != nil {
-		return []Team{}, fmt.Errorf("during account detail request: %w", err)
-	}
-	c.setCommonHeaders(req)
-
-	resp, err := c.client.Do(req)
-	if err != nil {
-		return []Team{}, fmt.Errorf("during account detail request prep: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return []Team{}, fmt.Errorf("unexpected response status from API, status: %d", resp.StatusCode)
+		return nil, err
 	}
 
-	response := map[string][]Team{
-		"teams": {},
-	}
-	err = json.NewDecoder(resp.Body).Decode(&response)
-	if err != nil {
-		return []Team{}, fmt.Errorf("error unmarshaling response body (account detail): %w", err)
-	}
-
-	list := response["teams"]
-	return list, nil
+	return response.Teams, nil
 }
 
-func (c *Client) Providers() ([]Provider, error) {
-	if err := c.login(); err != nil {
-		return []Provider{}, err
+func (c *Client) Providers(ctx context.Context) ([]Provider, error) {
+	route := c.resolve(routeProviders)
+
+	var response struct {
+		Providers []Provider `json:"providers"`
 	}
 
-	route := fmt.Sprint(c.apiTarget, routeProviders)
-
-	req, err := http.NewRequest(http.MethodGet, route, nil)
+	err := c.doJSON(ctx, http.MethodGet, route, &response)
 	if err != nil {
-		return []Provider{}, fmt.Errorf("during provider detail request: %w", err)
+		return nil, err
 	}
+
+	return response.Providers, nil
+}
+
+func (c *Client) doJSON(
+	ctx context.Context,
+	method string, route *url.URL, o any,
+) (outErr error) {
+	resp, err := c.do(ctx, method, route, nil)
+	if err != nil {
+		return err
+	}
+
+	defer safeClose(&outErr, resp.Body, "response body")
+
+	if resp.StatusCode != http.StatusOK {
+		return errorFromAPIMessageResponse(resp)
+	}
+
+	err = json.NewDecoder(resp.Body).Decode(o)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal response body: %w", err)
+	}
+
+	return nil
+}
+
+func (c *Client) doExec(
+	ctx context.Context,
+	method string, route *url.URL, statusCode int,
+) (outErr error) {
+	resp, err := c.do(ctx, method, route, nil)
+	if err != nil {
+		return err
+	}
+
+	defer safeClose(&outErr, resp.Body, "response body")
+
+	if resp.StatusCode != statusCode {
+		return errorFromAPIMessageResponse(resp)
+	}
+
+	return nil
+}
+
+func (c *Client) do(
+	ctx context.Context,
+	method string, route *url.URL, body io.Reader,
+	opts ...func(req *http.Request),
+) (*http.Response, error) {
+	if err := c.login(); err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(
+		ctx, method, route.String(), body,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
 	c.setCommonHeaders(req)
+
+	for i := range opts {
+		opts[i](req)
+	}
 
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return []Provider{}, fmt.Errorf("during provider detail request prep: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return []Provider{}, fmt.Errorf("unexpected response status from API, status: %d", resp.StatusCode)
+		return nil, fmt.Errorf("failed to perform request: %w", err)
 	}
 
-	response := map[string][]Provider{
-		"providers": {},
-	}
-	err = json.NewDecoder(resp.Body).Decode(&response)
-	if err != nil {
-		return []Provider{}, fmt.Errorf("error unmarshaling response body (provider list): %w", err)
-	}
-
-	list := response["providers"]
-	return list, nil
+	return resp, nil
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -66,13 +66,13 @@ func New(version string) func() *schema.Provider {
 				idConfigName: {
 					Type:        schema.TypeString,
 					Description: "The application id component of the Crunchy Bridge API key.",
-					DefaultFunc: schema.EnvDefaultFunc("APPLICATION_ID", nil),
+					DefaultFunc: schema.EnvDefaultFunc("APPLICATION_ID", ""),
 					Required:    true,
 				},
 				secretConfigName: {
 					Type:        schema.TypeString,
 					Description: "The application secret component of the Crunchy Bridge API key.",
-					DefaultFunc: schema.EnvDefaultFunc("APPLICATION_SECRET", nil),
+					DefaultFunc: schema.EnvDefaultFunc("APPLICATION_SECRET", ""),
 					Required:    true,
 				},
 				tokenConfigName: {
@@ -97,10 +97,9 @@ func New(version string) func() *schema.Provider {
 
 func configure(version string, p *schema.Provider) func(context.Context, *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	return func(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
-		// Setup diagnostic message slice
-		diags := []diag.Diagnostic{}
-
-		// Provider.UserAgent provides a UserAgent string with the passed parameters, Terraform version, SDK version, and other bits:
+		// Provider.UserAgent provides a UserAgent string with the
+		// passed parameters, Terraform version, SDK version, and other
+		// bits:
 		userAgent := p.UserAgent("terraform-provider-crunchybridge", version)
 
 		id := d.Get(idConfigName).(string)
@@ -133,6 +132,6 @@ func configure(version string, p *schema.Provider) func(context.Context, *schema
 			return nil, diag.FromErr(err)
 		}
 
-		return c, diags
+		return c, nil
 	}
 }


### PR DESCRIPTION
* Switch to float64 for cluster and plan memory. Consistently use GB suffix for memory.
* Use helper functions for making request, cutting down on boilerplate and making error handling more consistent.
* Always attempt to parse error response bodies on errors.
* Resolve endpoint routes using URL.ResolveReference().
* Add context support for all API calls.
* Capture Body.Close() errors when handling responses.
* Allow slices to be nil when empty, and generally make more use of zero values.
* Consistenly use typed structs instead of map[string]T for response parsing